### PR TITLE
add possibility to disable classes (Action/Request/RouteMap)

### DIFF
--- a/src/Propel/Generator/Behavior/Api/Api.php
+++ b/src/Propel/Generator/Behavior/Api/Api.php
@@ -14,11 +14,12 @@ use Propel\Generator\Model\Table;
 
 class Api extends Behavior
 {
-    
+
     const PARAM_action_class = 'action_class';
     const PARAM_entity_request_class = 'entity_request_class';
     const PARAM_route_map_class = 'route_map_class';
     const PARAM_ROUTES_PREFIX = 'auto_add_routes_prefix';
+    const PARAM_SKIP_CLASSES = 'skip_classes';
     /**
      * @var array
      */
@@ -34,15 +35,21 @@ class Api extends Behavior
      */
     protected $parameters = [
         self::PARAM_action_class         => 'Eukles\\Action\\ActionAbstract',
-        self::PARAM_entity_request_class => 'Eukles\\Entity\\EntityRequestMock',
-        self::PARAM_route_map_class      => 'Eukles\\RouteMap\\RouteMapMock',
+        self::PARAM_entity_request_class => 'Eukles\\Entity\\EntityRequestAbstract',
+        self::PARAM_route_map_class      => 'Eukles\\RouteMap\\RouteMapAbstract',
         self::PARAM_ROUTES_PREFIX        => '',
+        self::PARAM_SKIP_CLASSES         => false,
     ];
     /**
      * @var ObjectBuilder
      */
     private $builder;
     
+    public function hasAdditionalBuilders()
+    {
+        return $this->getParameter(self::PARAM_SKIP_CLASSES) !== "true";
+    }
+
     /**
      * @param ObjectBuilder $builder
      *

--- a/tests/Propel/Generator/Behavior/Api/SkipApiTest.php
+++ b/tests/Propel/Generator/Behavior/Api/SkipApiTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: steve
+ * Date: 23/03/17
+ * Time: 18:05
+ */
+
+namespace Propel\Generator\Behavior\Api;
+
+use PHPUnit\Framework\TestCase;
+use Propel\Generator\Util\QuickBuilder;
+use Util\SetUp;
+
+/**
+ * Class ApiTest
+ *
+ * @package Propel\Generator\Behavior\Api
+ */
+class SkipApiTest extends TestCase
+{
+    
+    /**
+     * @var QuickBuilder
+     */
+    protected $builder;
+    
+    /**
+     *
+     */
+    public function setUp()
+    {
+        $this->builder = SetUp::load('schema-skip', true);
+    }
+    
+    /**
+     *
+     */
+    public function testSkip()
+    {
+        $this->assertTrue(class_exists('ApiTest20Action'));
+        $this->assertFalse(class_exists('ApiTest21Action'));
+    }
+}

--- a/tests/util/schema-skip.xml
+++ b/tests/util/schema-skip.xml
@@ -1,0 +1,17 @@
+<database name="api_behavior_test_0">
+	<behavior name="api">
+		<parameter name="action_class" value="\Eukles\Action\ActionMock"/>
+		<parameter name="entity_request_class" value="\Eukles\Entity\EntityRequestMock"/>
+		<parameter name="route_map_class" value="\Eukles\RouteMap\RouteMapMock"/>
+	</behavior>
+	<table name="api_test_20">
+		<column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+	</table>
+
+	<table name="api_test_21">
+		<column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+		<behavior name="api">
+			<parameter name="skip_classes" value="true"/>
+		</behavior>
+	</table>
+</database>


### PR DESCRIPTION
this is useful when you apply modifer globally to database

Example
```
<database name="db">
	<behavior name="api" />
	<table name="with_extra_classes">
		<behavior name="autoAddPk">
	</table>

	<table name="WITHOUT_extra_classes">
		<behavior name="autoAddPk">
		<behavior name="api">
			<parameter name="skip_classes" value="true"/>
		</behavior>
	</table>
</database>
```